### PR TITLE
Fix typos and update links to reference manual

### DIFF
--- a/FAQ/BindEditor.txt
+++ b/FAQ/BindEditor.txt
@@ -13,12 +13,12 @@ is available) causes the internal Emacs clone to be used. Some examples:
 
 If the editor is not known to SWI-Prolog, it will open the file, but not
 locate the editor to source-locations. To tell Prolog how to open a file
-and jump to a specified line, add a clause to edit:edit_command/2 . See
+and jump to a specified line, add a clause to prolog_edit:edit_command/2 . See
 the example below. See library/edit.pl for details.
 
 ==
 :- multifile
-	edit:edit_command/2.
+	prolog_edit:edit_command/2.
 
 edit_command(myedit, '%e --line=%d "%f"').
 ==

--- a/FAQ/Customise.txt
+++ b/FAQ/Customise.txt
@@ -3,4 +3,4 @@
 Quite a lot. There are two mechanisms for customizing. Many options can
 be set using set_prolog_flag/2. Other things can be modified using
 hooks. The reference manual contains an overview of all
-[[available hooks][</man/hooks.html>]].
+[[available hooks][</pldoc/man?section=hooks>]].

--- a/FAQ/DynamicCode.txt
+++ b/FAQ/DynamicCode.txt
@@ -8,7 +8,7 @@ related predicate.
 
 Normally, *compiled* code results in *static* predicates. These cannot
 be modified at runtime. Knowing code is static helps the compiler. If
-you want to make _dynamic_ code, i.e., code that can be modified ar
+you want to make _dynamic_ code, i.e., code that can be modified at
 runtime, use the dynamic/1 directive. Normally you place this directive
 near the start of a file or just above the code:
 

--- a/FAQ/MakeExecutable.txt
+++ b/FAQ/MakeExecutable.txt
@@ -20,5 +20,5 @@ some cases:
 
     * WinExe.txt -- Make an executable of Prolog for MS-Windows
     * PceWinExe.txt -- Make an executable of an XPCE graphical
-    application for MS-WIndows
-    * UnixExe.txt -- Make exectable in Linux/Unix systems 
+    application for MS-Windows
+    * UnixExe.txt -- Make executable in Linux/Unix systems 

--- a/FAQ/Multifile.txt
+++ b/FAQ/Multifile.txt
@@ -8,7 +8,7 @@ are two situations:
   different predicates.  Now, there are two ways out:
 
     - Rename the predicate in one of the two files.
-    - Start using [[modules][</man/modules.html>]].
+    - Start using [[modules][</pldoc/man?section=modules>]].
 
   2. This was intended: you want different clauses of the p/1 predicate
   in different clauses.  There are again two ways out:

--- a/FAQ/Multifile.txt
+++ b/FAQ/Multifile.txt
@@ -47,7 +47,7 @@ are two situations:
   and all lookup is fully indexed. The price is that you have little
   control over the order of the clauses. If you modify file 1 and reload
   it, its clauses will now be _after_ those from file 2.  Make sure that
-  the order does not matter!  The second appraoch maintains the order of
+  the order does not matter!  The second approach maintains the order of
   answers. This approach is typically preferred if the facts from file 1
   and file 2 are conceptually different, e.g., the first defines people
   and the second organizations.

--- a/FAQ/NoXPCE.txt
+++ b/FAQ/NoXPCE.txt
@@ -5,14 +5,14 @@ you sometimes get and sometimes don't get this error. What is the
 problem?
 
 The :- pce_begin_class directive is handled using term_expansion/2 if
-XPCE is loaded. Unlike predicates, term_expansion rulea are not
+XPCE is loaded. Unlike predicates, term_expansion rules are not
 autoloaded. Thus, if you reference an XPCE predicate first or otherwise
 force XPCE to load, all is fine, but if the first XPCE reference is a
 new class it fails.
 
 ---+ What to do?
 
-Load XPCE explicitely by starting a file or module that uses it with the
+Load XPCE explicitly by starting a file or module that uses it with the
 load-command:
 
 ==

--- a/FAQ/PceEmacs.txt
+++ b/FAQ/PceEmacs.txt
@@ -1,7 +1,7 @@
 ---+ Using PceEmacs
 
-The XPCE GUI tool for Prolog comes with a build-in emacs clone written
-in Prolog. It's Prolog mode does proper indentation, full syntax
+The XPCE GUI tool for Prolog comes with a built-in emacs clone written
+in Prolog. Its Prolog mode does proper indentation, full syntax
 checking by calling the SWI-Prolog parser, warning for singleton
 variables and finding predicate definitions based on the
 source-information from the Prolog database. Syntax colouring of clause

--- a/FAQ/PceWinExe.txt
+++ b/FAQ/PceWinExe.txt
@@ -23,10 +23,10 @@ define this the location for our icons using
 
 Next, we define images we want to use as SWI-Prolog resources. See
 resource/3 in the SWI-Prolog reference manual for details. Assume we
-have print.xpm in the cions directory and we want to make an image
+have print.xpm in the icons directory and we want to make an image
 thereof. This is done using the code below. The first fact declares the
 resource print as a resource of type image whose data is in the file
-image('print.xpm'). The file argument followes the files-specification
+image('print.xpm'). The file argument follows the files-specification
 rules defined by absolute_file_name/3. The directive
 pce_image_directory/1 above adds icons to the image search path as well
 as to the XPCE search-path for images. Finally, resource(print) defines

--- a/FAQ/PlInitialisation.txt
+++ b/FAQ/PlInitialisation.txt
@@ -1,7 +1,7 @@
 # Site and personal initialisation files
 
 On startup, SWI-Prolog reads both site initialisation and personal
-initialisation files. Both can be controlled explicitely using
+initialisation files. Both can be controlled explicitly using
 commandline options (*|-F base|* for site, and *|-f base|* for personal
 initialisation).
 

--- a/FAQ/PrologScript.txt
+++ b/FAQ/PrologScript.txt
@@ -22,7 +22,7 @@ main(Argv) :-
 ==
 
 More information on using PrologScript as well as more compilation
-issues can be found in the [[Reference Manual][<man/compilation.html>]].
+issues can be found in the [[Reference Manual][</pldoc/man?section=compilation>]].
 
 ---++ Windows
 

--- a/FAQ/PrologScript.txt
+++ b/FAQ/PrologScript.txt
@@ -22,7 +22,7 @@ main(Argv) :-
 ==
 
 More information on using PrologScript as well as more compilation
-issues can be found in the [[Reference Manaual][<man/compilation.html>]].
+issues can be found in the [[Reference Manual][<man/compilation.html>]].
 
 ---++ Windows
 

--- a/FAQ/SingletonVar.txt
+++ b/FAQ/SingletonVar.txt
@@ -33,5 +33,5 @@ better('SWI-Prolog', AnyOtherProlog?).
 
 Note: changes to the style_check/1 options are reverted at the end of
 the file the directive appears in. See also [[Syntax
-Notes][</man/syntax.html>]] in the reference manual.
+Notes][</pldoc/man?section=syntax>]] in the reference manual.
 

--- a/FAQ/StackSizes.txt
+++ b/FAQ/StackSizes.txt
@@ -1,7 +1,7 @@
 ---+ How do I enlarge the stacks?
 
 Old versions of SWI-Prolog had quite limited default stack-sizes. As of
-version 5.10, there are no resources involved with unused spack-space
+version 5.10, there are no resources involved with unused stack-space
 and the limits on 32-bit platforms are by default the maximum that can
 be handled on these platforms: 128Mb. On 64-bit platforms the default is
 256Mb, which typically means you have roughly the same limit as on

--- a/FAQ/UndefinedCode.txt
+++ b/FAQ/UndefinedCode.txt
@@ -20,14 +20,14 @@ dynamic:
 ---++ You removed all clauses of a dynamic predicate using abolish/1
 
 abolish/1 forgets everything Prolog knows about the predicate, including
-the fact is was dynamic. All clauses should be removed using
+the fact that was dynamic. All clauses should be removed using
 retractall/1.  See also DynamicCode.txt.
 
 ---++ You enter your program at the prompt
 
 SWI-Prolog (in fact almost any Prolog system) interprets terms typed to
-the ?- prompt as queries and wants to prove (i.e., run) them. Way
-prefered is to use an editor to create a file and load this into Prolog
+the ?- prompt as queries and wants to prove (i.e., run) them. The
+preferred way is to use an editor to create a file and load this into Prolog
 by putting it between square brackets (see also LoadProgram.txt).
 
 ==

--- a/FAQ/floats.txt
+++ b/FAQ/floats.txt
@@ -18,7 +18,7 @@ A = 3.141592653589793.
 
 Floating point numbers are not exact. If you want exact arithmetic,
 please check out SWI-Prolog's support for rational numbers in the
-[[manual][</man/arith.html>]].
+[[manual][</pldoc/man?section=arith>]].
 
 Quoting Richard O'Keefe:
 

--- a/FAQ/floats.txt
+++ b/FAQ/floats.txt
@@ -16,7 +16,7 @@ Pi = 3.14159
 A = 3.141592653589793.
 ==
 
-Floating point numbers are not exact. If you want exact arthmetic,
+Floating point numbers are not exact. If you want exact arithmetic,
 please check out SWI-Prolog's support for rational numbers in the
 [[manual][</man/arith.html>]].
 

--- a/FAQ/index.txt
+++ b/FAQ/index.txt
@@ -1,8 +1,8 @@
 ---+ The SWI-Prolog FAQ
 
   * *|Getting started|*
-    * [[Getting started quickly (from the manual)][</man/quickstart.html>]]
-    * [[Initialising and Managing a Prolog project (from the manual)][</man/IDE.html>]]
+    * [[Getting started quickly (from the manual)][</pldoc/man?section=quickstart>]]
+    * [[Initialising and Managing a Prolog project (from the manual)][</pldoc/man?section=IDE>]]
     * [[How do I load a program?][LoadProgram.txt]]
     * [[How do I load a file from the library?][LoadLibrary.txt]]
 

--- a/FAQ/reconsult.txt
+++ b/FAQ/reconsult.txt
@@ -9,5 +9,5 @@ see multifile/1.
 
 @see For reloading files after editing, use make/0.
 @see For more info on sourcecode management, see [[Initialising and
-Managing a Prolog project][</man/IDE.html>]] from the SWI-Prolog
+Managing a Prolog project][</pldoc/man?section=IDE>]] from the SWI-Prolog
 reference manual.

--- a/features.txt
+++ b/features.txt
@@ -164,7 +164,7 @@ links to the relevant documentation.
     * *UNICODE* character set handling internal. Ideal for web and
     international applications.
 
-    * *|[[Multi-threading][</man/threads.html>]]|* support: run multiple
+    * *|[[Multi-threading][</pldoc/man?section=threads>]]|* support: run multiple
     pre-emptively scheduled prolog engines on the same database.
 
     * [*Engines*](</pldoc/man?section=engines>), also known as
@@ -188,9 +188,9 @@ links to the relevant documentation.
 ### Constraint handling
 
     * Libraries for
-    *|[[CHR][</man/chr.html>]]|* (Constraint Handling
-    Rules), *|[[clp(FD)][</man/clpfd.html>]]|*,
-    *|[[clp(R,Q)][</man/clpqr.html>]]|* and various others.
+    *|[[CHR][</pldoc/man?section=chr>]]|* (Constraint Handling
+    Rules), *|[[clp(FD)][</pldoc/man?section=clpfd>]]|*,
+    *|[[clp(R,Q)][</pldoc/man?section=clpqr>]]|* and various others.
 
 ### Connectivity
 

--- a/gxref.txt
+++ b/gxref.txt
@@ -1,8 +1,8 @@
 ---+ SWI-Prolog XREF --- Cross-Referencing Tool
 
 The SWI-Prolog Cross-Referencer can be used to examine the currently
-loaded program, creating a hiearchical file overview with icons
-indicating which files have suspicious code, a dependecy view as shown
+loaded program, creating a hierarchical file overview with icons
+indicating which files have suspicious code, a dependency view as shown
 below and detailed info per file as shown below that. To analyse a
 program, load it into Prolog and, simply run gxref/0:
 
@@ -14,7 +14,7 @@ program, load it into Prolog and, simply run gxref/0:
 
 			[[xrefchatdep.gif]]
 
-File-dependecy view. Views can be created for the whole project, per
+File-dependency view. Views can be created for the whole project, per
 directory or selectively by adding files to the view.
 
 ---++ XREF - File info

--- a/howto/ForeignPack.txt
+++ b/howto/ForeignPack.txt
@@ -61,7 +61,7 @@ dependencies between Prolog and the extension.  In particular:
   $ Linux :
   Linux ELF objects (*|.so|* files) resolve symbols against already
   loaded symbols, which makes the extension independent from the
-  location of SWI-Prolog and the version.  The downsite is that
+  location of SWI-Prolog and the version.  The downside is that
   Linux shared object that depend on many system features are often
   not binary compatible due to different versions of dependencies.
 
@@ -163,8 +163,8 @@ mentioned variables replace the above described value.
 ---+++ Windows MinGW builds
 
 The infrastructure assumes using [[MinGW][http://www.mingw.org]] and
-MSYS for building foreign packages on Windows. In pack_install/1 detects
-an a foreign pack on Windows, it performs the following steps to prepare
+MSYS for building foreign packages on Windows. If pack_install/1 detects
+a foreign pack on Windows, it performs the following steps to prepare
 MinGW:
 
   1. If gcc.exe and make.exe are in %PATH%, use them.


### PR DESCRIPTION
Fix minor typos.

Update the links to reference manual, so the reference manual looks consistent.