### PR TITLE
Fix typos and broken link

### DIFF
--- a/build/WebAssembly.txt
+++ b/build/WebAssembly.txt
@@ -11,7 +11,7 @@ You need to download the Emscripten  compiler. Follow the instruction on
 its
 [homepage](http://kripken.github.io/emscripten-site/docs/getting_started/downloads.html).
 
-After the successful installation load the Emscripten environment into the current terminal session (asjust path):
+After the successful installation load the Emscripten environment into the current terminal session (adjust path):
 
     source ./emsdk_env.sh
 

--- a/build/issues/RebuildAfterDevLib.txt
+++ b/build/issues/RebuildAfterDevLib.txt
@@ -1,6 +1,6 @@
 # Fix incomplete installation due to missing dependencies
 
-Sometimes SWI-Prolog is lacks features or packages because the required
+Sometimes SWI-Prolog lacks features or packages because the required
 dependencies were not available while compiling the system from source.
 Installed features and packages can be checked using
 check_installation/0 (requires SWI-Prolog 7.1.10 or later). Issues found
@@ -25,7 +25,7 @@ steps.
      See =README.mingw= for downloading and installing dependencies.
 
   2. Redo the build.  If you have not much experience, the best option is simply
-     to redo the whole [build](<build/unix.html>).
+     to redo the whole [build](</build/unix.html>).
 
      ==
      % make distclean

--- a/build/issues/odbc.txt
+++ b/build/issues/odbc.txt
@@ -1,7 +1,7 @@
 # Issues with library(odbc)
 
 The library(odbc) can be used to connect to relational databases, such as MySQL,
-Postgress, Microsoft SQL server, etc.
+Postgres, Microsoft SQL server, etc.
 
 ## Consequences
 
@@ -15,6 +15,6 @@ as well as the *sql.h* header.
 
 ### MacOS binary
 
-The MacOSX binary package does *not* contain library(odbc).  Maverics does probide
+The MacOSX binary package does *not* contain library(odbc).  Mavericks does provide
 iodbc.dylib, but the development system does not provide sql.h.  Please contact
 bugs@swi-prolog.org if you know a solution to this problem.

--- a/build/issues/readline.txt
+++ b/build/issues/readline.txt
@@ -1,7 +1,7 @@
 # Issues with library(readline)
 
 The library(readline) is based on [GNU
-readline](https://cnswww.cns.cwru.edu/php/chet/readline/rltop.html),
+readline](https://tiswww.case.edu/php/chet/readline/rltop.html),
 providing command line editing for the terminal on Unix-like systems.
 
 ## Consequences

--- a/build/issues/readline.txt
+++ b/build/issues/readline.txt
@@ -22,7 +22,7 @@ more powerful editor.
 Install the development package for libreadline.  This is available on
 many platforms.
 
-  $ Debian/Ubutu :
+  $ Debian/Ubuntu :
   =|$ apt-get install libreadline-dev|=
 
 After installing the development library, [re-install the

--- a/build/unix.txt
+++ b/build/unix.txt
@@ -62,7 +62,7 @@ holding different configurations. A built system can simply be removed
 by removing the build directory. Basic instruction to build the system
 are below. The first alternative installs the system in your home
 directory and used [ninja](https://ninja-build.org/) to build the
-system. The second alternative uses classicaly `make` and installs in
+system. The second alternative uses classical `make` and installs in
 `/usr/local`. The `ctest -j 4` tests the system using 4 parallel jobs.
 Testing is encouraged but not required.
 

--- a/build/unixautotools.txt
+++ b/build/unixautotools.txt
@@ -1,7 +1,7 @@
 # Building on Unix using GNU autotools
 
 This page describes building SWI-Prolog from source for versions prior
-to 7.7.20. More recent versions are build using
+to 7.7.20. More recent versions are built using
 [cmake](https://cmake.org/). The process is described on [this
 page](<unix.html>).
 
@@ -106,7 +106,7 @@ of required libraries.
 ==
 
 *configure* is a Bourne Shell script doing the actual configuration for
-your computer. The most important options of confure are:
+your computer. The most important options of configure are:
 
     $ --help :
     Print a list of all available options. See the files INSTALL and
@@ -123,7 +123,7 @@ your computer. The most important options of confure are:
     Overrides the directory for installing the executables to
     exec_prefix/bin/, normally used on heterogeneous networks.
 
-After succesfull installation, the compilation directory may be removed.
+After successful installation, the compilation directory may be removed.
 
 ### In case of trouble ...
 


### PR DESCRIPTION
Fix minor typos and a broken link to GNU Readline website.