### PR TITLE
Fix typos

### DIFF
--- a/IDE.txt
+++ b/IDE.txt
@@ -8,7 +8,7 @@ improve the user experience for the regular Prolog programmer.
 
 ### Built-in tools
 
-The built-in tools provide a feature rich evironment for developing with
+The built-in tools provide a feature rich environment for developing with
 SWI-Prolog. The tools are built on top of the portable XPCE graphics
 system. They look outdated and the learning curve for the built-in Emacs
 clone is steep. The real-time semantic highlighting greatly reduces the
@@ -58,7 +58,7 @@ running Prolog. It provides a [CodeMirror](https://codemirror.net/)
 based editor with server-enriched semantic highlighting based on the
 same library as the above mentioned built-in editor. SWISH can display
 Prolog results as tables, charts and anything supported by HTML5 and
-JavaScript. SWISH *notebooks* provide functonality inspired by
+JavaScript. SWISH *notebooks* provide functionality inspired by
 [Jupyter/IPython notebook](https://ipython.org/).
 
 SWISH provides a smooth transition starting with conventional Prolog

--- a/bug.txt
+++ b/bug.txt
@@ -21,7 +21,7 @@ is just a guideline, but if any of these parts are missing it is very likely tha
 
   1. The version of SWI-Prolog you use and the operating system.
   2. A clear description on how to reproduce the issue.  Typically,
-     his consists of:
+     this consists of:
      - A _complete_ program.  Please do not send merely a fragment
        because
          1. It costs us a lot of time to complete and

--- a/build/guidelines.txt
+++ b/build/guidelines.txt
@@ -62,7 +62,7 @@ Building follows standard CMake procedures.  The   system  can  be built
 using _Profile Guided Optimization_  (PGO),  which   makes  it  about 7%
 faster. To do so
 
-  1. Configure using cmake using the Ninja build tool (-G Ninja)
+  1. Configure cmake using the Ninja build tool (-G Ninja)
   2. Run ../script/pgo-compile.sh
   3. Run Ninja
 

--- a/community.txt
+++ b/community.txt
@@ -31,7 +31,7 @@ We appreciate your patience.
 The [forum and mailing list](https://swi-prolog.discourse.group) for
 SWI-Prolog is kindly hosted by [Discourse](https://www.discourse.org/).
 This list is used for announcements as well as questions and discussion
-amoung users. On average, traffic is 5-10 messages per day. Details:
+among users. On average, traffic is 5-10 messages per day. Details:
 
   - The forum can be viewed [here](https://swi-prolog.discourse.group)
 

--- a/howto/http/Access80.txt
+++ b/howto/http/Access80.txt
@@ -12,7 +12,7 @@ This used to be rare, but given today's good and cheap virtualization it
 becomes a real option.  The library(http/http_unix_daemon) provides the
 infrastructure, including a =|/etc/init.d|= script for Debian for starting
 a server using root privileges, opening a reserved port, registering the
-service in =|/var/run|=, talking to the Unix syslog deamon and finally
+service in =|/var/run|=, talking to the Unix syslog daemon and finally
 dropping privileges to a given user and group.
 
 ---++ Using Apache

--- a/howto/http/HTMLParams.txt
+++ b/howto/http/HTMLParams.txt
@@ -1,7 +1,7 @@
 ---++ Processing HTTP-parameters
 
 In HTMLRules.txt, we used the HTML generation library to build a single
-page dynamicaly.  In this page we will introduce two new primitives:
+page dynamically.  In this page we will introduce two new primitives:
 
     1. Create a handler that processes parameters
     2. Create a URI to another handler dynamically
@@ -154,7 +154,7 @@ In this page we learned linking dynamically generated pages together and
 passing parameters. The same infrastructure can of course be used to
 generate forms as we discuss in HTMLForms.txt. We also learned how to
 deal with reusability and maintenance by properly splitting the code
-and by refering to HTTP paths by the predicate that implements them
+and by referring to HTTP paths by the predicate that implements them
 rather than the exact location of the server.
 
 ---+++ What is still missing?
@@ -162,7 +162,7 @@ rather than the exact location of the server.
 If you loaded the source and ran the demo, you might feel a bit
 disappointed: it works flawlessly, but it looks very 1980's: totally
 basic style and no fancy interaction. With the technology presented
-sofar, we can easily make it look 1990's: create reusable rules that
+so far, we can easily make it look 1990's: create reusable rules that
 create tables-in-tables(-in-frames)! In HTMLStyle.txt, we discuss how to
 do this state-of-the-art.
 

--- a/howto/http/HTMLRules.txt
+++ b/howto/http/HTMLRules.txt
@@ -36,7 +36,7 @@ list_modules(_Request) :-
 Now, we complete the definition of the skeleton by providing definitions
 for the called rules. These definitions are
 [[DCGs][http://cs.union.edu/~striegnk/learn-prolog-now/html/node54.html#lecture7]]
-(Definite Clause Gammar rules). The _input_ arguments of the DCG rules
+(Definite Clause Grammar rules). The _input_ arguments of the DCG rules
 are parameters and the _output_ list is a list of HTML tokens created by
 means of calling html//1. The argument of html//1 must obey the same
 rules as the arguments of reply_html_page/2.

--- a/howto/http/HTMLStyle.txt
+++ b/howto/http/HTMLStyle.txt
@@ -81,7 +81,7 @@ server(Port) :-
 
 %%	home(+Request)
 %
-%	Privides the initial page of the LOD-crawler with a form
+%	Provides the initial page of the LOD-crawler with a form
 %	to search on http://sindice.com
 
 home(_Request) :-

--- a/howto/http/HTTPScale.txt
+++ b/howto/http/HTTPScale.txt
@@ -20,7 +20,7 @@ The concurrency model of the server is organised as follows.
 
     2. A worker that receives a connection from the accept-thread reads
     and parses the HTTP request-header.  It is given a limited time to
-    receive the header, so mallicious clients that stop after sending
+    receive the header, so malicious clients that stop after sending
     an incomplete header are disconnected.  Next, it typically calls
     http_dispatch/1 to process the request.  Without any further
     precautions, the worker processes the entire request before it
@@ -33,15 +33,15 @@ complete the request while the worker returns to the acceptor-queue.
 This can be achieved in two ways: by `hand' using http_spawn/2 or
 centralised using the option spawn(+Spec) in the option-list of
 http_handler/3. This mechanism can create threads in two ways: unbounded
-or bounded by a dynamic pool. Unbounded creation carries the risc of
+or bounded by a dynamic pool. Unbounded creation carries the risk of
 running out of resources.  Pool-bounded creation is therefore often the
 way to go.
 
 Pools are created using thread_pool_create/3. A pool has a name, maximum
 number of workers and some additional parameters.  Using multiple pools,
 we can create separate bounds for different tasks of the server, such as
-CPU intensitive tasks or tasks sending large files.  You do not want too
-many concurrent users with CPU intensitive jobs, while you may want many
+CPU intensive tasks or tasks sending large files.  You do not want too
+many concurrent users with CPU intensive jobs, while you may want many
 concurrent users that merely download large files (an operation that can
 take long if the connection is slow).  Here is a simple example with two
 pools:
@@ -68,7 +68,7 @@ following topics:
     * Show how to create a web-page where intermediate results are
       printed as they become available.
 
-If you run this demo, it is adviced to run the thread-monitor.  This can
+If you run this demo, it is advised to run the thread-monitor.  This can
 be started from the plwin.exe menu or by typing:
 
 ==

--- a/howto/http/HelloHTML.txt
+++ b/howto/http/HelloHTML.txt
@@ -62,7 +62,7 @@ Now, you may ask *|"Where's the beef?"|* True, this syntax is surely
 less readable than HTML or XML. This way of producing web-pages is
 intended for _dynamic_ web-pages. Fully static pages are much better
 [[served from files][<ServeFiles.html>]]. For mixed files with large
-static parts and e.g., a dynamic table, [[PWP][PWP.txt]] is a the
+static parts and e.g., a dynamic table, [[PWP][PWP.txt]] is the
 Prolog-based answer to PHP, ASP, JSP, etc.
 
 One way to deploy the above described library(http/html_write) is to

--- a/howto/http/ServerInit.txt
+++ b/howto/http/ServerInit.txt
@@ -13,7 +13,7 @@ starts a number of server threads and then presents the normal
 interactive Prolog toplevel. This is great for development and under the
 [[VNC][ServerVNC.txt]] solution, but of no use for a non-interactive
 server, because Prolog terminates if it reads an end-of-file at the
-toplevel.  We need to give the toplevel somthing to do.  The common
+toplevel.  We need to give the toplevel something to do.  The common
 solution is to use thread_get_message/1 for that because it provides
 a non-polling indefinite sleep that can be stopped by sending a message
 to the thread.  For example:

--- a/howto/http/ServerVNC.txt
+++ b/howto/http/ServerVNC.txt
@@ -20,7 +20,7 @@ on a heavily loaded server.
 ---++ Setting up VNC on Debian/Ubuntu
 
 Unfortunately, the setup requires root privileges and some Unix skills.
-Bwloe, we outline the steps for Debian and Debian derived systems (e.g.,
+Below, we outline the steps for Debian and Debian derived systems (e.g.,
 Ubuntu). This can serve as a starting point for all Unix-based systems.
 We assume TightVNC, root privileges and these steps create a user
 =wwwswi=.

--- a/pengines/AppLogic.txt
+++ b/pengines/AppLogic.txt
@@ -54,6 +54,6 @@ now?  There are several reasons and work-arounds.
   it is written properly and declare it using sandbox:safe_primitive/1.
 
   $ The API has side effects, but that it what it should do :
-  Make sure that the API corectly validates arguments and really
+  Make sure that the API correctly validates arguments and really
   cannot do anything unintended and declare it using
   sandbox:safe_primitive/1.

--- a/pengines/GenealogistMoreGUI.txt
+++ b/pengines/GenealogistMoreGUI.txt
@@ -13,7 +13,7 @@ apps/
    swish\
    scratchpad\
   ~~~~
-The file =|genealogist.pl|= has not changed since part 3, so we will not say more about it here. The CSS in =|genealogist.css|= is fairly uninteresting so we keep silent abot that too. Let us begin by looking at the HTML:
+The file =|genealogist.pl|= has not changed since part 3, so we will not say more about it here. The CSS in =|genealogist.css|= is fairly uninteresting so we keep silent about that too. Let us begin by looking at the HTML:
 
   ~~~~
   <!DOCTYPE html>

--- a/pengines/PengineConcept.txt
+++ b/pengines/PengineConcept.txt
@@ -16,7 +16,7 @@ by what is printed on the two screens.
 Fortunately, equipped with the pengines library you don't need two
 computers or two SWI-Prolog main processes to program in this way.
 You can run pengine_create([name('A')]) and pengine_create([name('B')]) 
-in the same shell. Better yet, it doesnt
+in the same shell. Better yet, it doesn't
 even have to be you doing the programming! Instead, you can write a
 program that based on what comes back from A and/or B sends the next
 command (or whatever needs to be done) to A and/or to B.
@@ -33,7 +33,7 @@ written to be run from a CLI are extremely easy to port to Pengines.
 You basically only have to replace calls to write/1 with calls to
 pengine_output/1 and calls to read/1 with calls to pengine_input/2.
 For your users' experience it may of course mean a lot since you can
-choose to repond with JSON and use the JSON to influence the behaviour
+choose to respond with JSON and use the JSON to influence the behaviour
 of a nice GUI, rather than a behaviour in terms of what is read from
 or written to a CLI.
 


### PR DESCRIPTION
In `pengines/GenealogistMoreGUI.txt`, `git diff` showed `No newline at end of file` at line 187.

Before the commit, `wc -l` prints 186 newline counts.

After the commit, `wc -l` prints 187 newline counts.

I didn't fix it, so Git might have fixed that issue automatically.