### PR TITLE
updated ##prolog location to reflect libera move

### DIFF
--- a/community.txt
+++ b/community.txt
@@ -16,8 +16,7 @@ about SWI-Prolog or Prolog programming in general.
     (best place for issues with class room exercises that are not
     SWI-Prolog specific)
 
-    - The Prolog IRC channel ##prolog on FreeNode
-    can be accessed via [WebChat](http://webchat.freenode.net/?channels=##prolog)
+    - The Prolog IRC channel ##prolog has moved to libera.chat (server irc.libera.chat)
 
     - [SWI-Prolog issue tracker at GitHub](https://github.com/SWI-Prolog/issues/issues)
     (See [reporting a bug](<bug.html>) for guidelines about reporting


### PR DESCRIPTION
FreeNode, the former IRC server for ##prolog, has had a hostile takeover. The entire freenode staff, along
with the vast majority of the user communities, have moved to libera.chat.  This PR updates our community page to reflect this change.