### PR TITLE
update dll list for windows standalone exe

### DIFF
--- a/FAQ/WinExe.txt
+++ b/FAQ/WinExe.txt
@@ -11,15 +11,13 @@ swipl.exe -o myapp.exe -c load.pl --goal=main
 
 To run, =|myapp.exe|= requires *|.dll|* files from the installation's
 =bin= directory. The required *|.dll|* files are listed below. Note that
-the details may depend on the version and installation. Notably
-=|libdwarf.dll|= may not be present and the others may have a different
-version.
+the details may depend on the version and installation.
 
-  - =|libswipl.dll|=
-  - =|libdwarf.dll|=
-  - =|libgmp-10.dll|=
-  - =|libwinpthread-1.dll|=
   - =|libgcc_s_seh-1.dll|=
+  - =|libgmp-10.dll|=
+  - =|libswipl.dll|=
+  - =|libwinpthread-1.dll|=
+  - =|zlib1.dll|=
 
 Your application may depend on additional *|.dll|* files loaded through
 use_foreign_library/1. You can find these with


### PR DESCRIPTION
It seems the existing documentation here is a bit outdated. The new list is exactly the same as before, except that `libdwarf.dll` seems to no longer be necessary and `zlib1.dll` now seems to be required. I also alphabetized the list.

I got to this list through trial and error, and notably I did not ever encounter a specific error message stating that `zlib1.dll` was missing. I just happened to see a post where it was suggested in the swipl discourse forum.